### PR TITLE
Fix: engn1120-fall-tag.yml

### DIFF
--- a/.github/workflows/engn1120-fall-tag.yml
+++ b/.github/workflows/engn1120-fall-tag.yml
@@ -5,6 +5,7 @@ env:
   CLASS: engn1120
   TARGET: base
   SQLITE: true
+  PYTHON_VERSION: 3.7
 
 jobs:
   build:


### PR DESCRIPTION
oops. I forgot to set the `PYTHON_VERSION` in the tagging workflow