### PR TITLE
fix: add scikit-image to the apma docker image

### DIFF
--- a/requirements/classes/apma0350/requirements.txt
+++ b/requirements/classes/apma0350/requirements.txt
@@ -6,7 +6,8 @@ matplotlib-base
 numpy 
 pandas 
 pip
-scikit-learn 
+scikit-learn
+scikit-image
 scipy
 seaborn
 sympy


### PR DESCRIPTION
This PR is to update the APMA Docker image to include the Scikit-Image package. 