### PR TITLE
NEUR1630 Github Dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,16 +53,6 @@ RUN fix-permissions "${CONDA_DIR}" && \
 
 USER root
 
-# Install missing fonts
-RUN cd /usr/share/fonts && \
-    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-bold.otf && \
-    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-bolditalic.otf && \
-    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-italic.otf && \
-    wget http://mirrors.ctan.org/fonts/tex-gyre/opentype/texgyrepagella-regular.otf && \
-    wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansMono-unhinted.zip && \
-    unzip NotoSansMono-unhinted.zip && \
-    chmod +r -R /usr/share/fonts
-
 RUN fc-cache -fsv 
 RUN mktexlsr
 

--- a/requirements/classes/neur1630/requirements.pip.txt
+++ b/requirements/classes/neur1630/requirements.pip.txt
@@ -13,4 +13,5 @@ rastermap
 zenodo-get
 cellxgene-census
 ONE-api
-#git+https://github.com/alleninstitute/abc_atlas_access.git
+git+https://github.com/alleninstitute/abc_atlas_access.git
+PyYAML>=6.0.0

--- a/requirements/classes/neur1630/requirements.pip.txt
+++ b/requirements/classes/neur1630/requirements.pip.txt
@@ -8,4 +8,9 @@ pynapple
 pybiomart
 pyranges
 gseapy
+gdown
+rastermap
+zenodo-get
+cellxgene-census
+ONE-api
 git+https://github.com/alleninstitute/abc_atlas_access.git

--- a/requirements/classes/neur1630/requirements.pip.txt
+++ b/requirements/classes/neur1630/requirements.pip.txt
@@ -8,3 +8,4 @@ pynapple
 pybiomart
 pyranges
 gseapy
+git+https://github.com/alleninstitute/abc_atlas_access.git

--- a/requirements/classes/neur1630/requirements.pip.txt
+++ b/requirements/classes/neur1630/requirements.pip.txt
@@ -13,4 +13,4 @@ rastermap
 zenodo-get
 cellxgene-census
 ONE-api
-git+https://github.com/alleninstitute/abc_atlas_access.git
+#git+https://github.com/alleninstitute/abc_atlas_access.git

--- a/requirements/classes/neur1630/requirements.txt
+++ b/requirements/classes/neur1630/requirements.txt
@@ -14,7 +14,7 @@ fastcluster
 tqdm
 pynwb
 dandi
-git+https://github.com/alleninstitute/abc_atlas_access
+git+https://github.com/alleninstitute/abc_atlas_access.git
 
 # these are the scipy base packages ( YOU PROBABLY DON'T WANT TO REMOVE THESE )
 dask 

--- a/requirements/classes/neur1630/requirements.txt
+++ b/requirements/classes/neur1630/requirements.txt
@@ -14,7 +14,6 @@ fastcluster
 tqdm
 pynwb
 dandi
-git+https://github.com/alleninstitute/abc_atlas_access.git
 
 # these are the scipy base packages ( YOU PROBABLY DON'T WANT TO REMOVE THESE )
 dask 

--- a/requirements/classes/neur1630/requirements.txt
+++ b/requirements/classes/neur1630/requirements.txt
@@ -1,5 +1,4 @@
 # add class-specific packages here:
-
 ipywidgets
 zarr
 requests
@@ -15,6 +14,7 @@ fastcluster
 tqdm
 pynwb
 dandi
+git+https://github.com/alleninstitute/abc_atlas_access
 
 # these are the scipy base packages ( YOU PROBABLY DON'T WANT TO REMOVE THESE )
 dask 


### PR DESCRIPTION
Adds `git+https://github.com/alleninstitute/abc_atlas_access.git` as a dependency in requirements.txt for the NEUR1630 image.